### PR TITLE
add possibility to make sell_refund_correction requests to Atol v5

### DIFF
--- a/src/V5/AtolApi.php
+++ b/src/V5/AtolApi.php
@@ -20,6 +20,7 @@ final class AtolApi
     private const OPERATION_SELL = 'sell';
     private const OPERATION_SELL_REFUND = 'sell_refund';
     private const OPERATION_SELL_CORRECTION = 'sell_correction';
+    private const OPERATION_SELL_REFUND_CORRECTION = 'sell_refund_correction';
 
     /**
      * @var ClientInterface
@@ -73,6 +74,11 @@ final class AtolApi
     public function sellCorrection(string $groupCode, string $token, CorrectionRequest $request): CorrectionResponse
     {
         return $this->correction(self::OPERATION_SELL_CORRECTION, $groupCode, $token, $request);
+    }
+
+    public function sellRefundCorrection(string $groupCode, string $token, CorrectionRequest $request): CorrectionResponse
+    {
+        return $this->correction(self::OPERATION_SELL_REFUND_CORRECTION, $groupCode, $token, $request);
     }
 
     public function report(string $groupCode, string $token, string $uuid): ReportResponse

--- a/tests/Functional/V5/AtolApiTest.php
+++ b/tests/Functional/V5/AtolApiTest.php
@@ -121,6 +121,18 @@ final class AtolApiTest extends AtolApiTestCase
         $this->appendErrorRegisterResponse();
     }
 
+    protected function setUpTestSellRefundCorrection(): void
+    {
+        $this->appendSuccessTokenResponse();
+        $this->appendSuccessRegisterResponse();
+    }
+
+    protected function setUpTestSellRefundCorrectionWithInvalidRequest(): void
+    {
+        $this->appendSuccessTokenResponse();
+        $this->appendErrorRegisterResponse();
+    }
+
     protected function setUpTestReport(): void
     {
         $this->appendSuccessTokenResponse();

--- a/tests/Integrational/V5/AtolApiTest.php
+++ b/tests/Integrational/V5/AtolApiTest.php
@@ -113,4 +113,14 @@ final class AtolApiTest extends AtolApiTestCase
     {
         // nothing
     }
+
+    protected function setUpTestSellRefundCorrection(): void
+    {
+        // nothing
+    }
+
+    protected function setUpTestSellRefundCorrectionWithInvalidRequest(): void
+    {
+        // nothing
+    }
 }


### PR DESCRIPTION
according to atol api and business issues, we should have possibility to make sell_refund_correction reciepts
its a kind of correction bills in v5 api